### PR TITLE
Update outdated content script patterns for Hibernate Search

### DIFF
--- a/_outdated-content/outdated-content.js
+++ b/_outdated-content/outdated-content.js
@@ -84,13 +84,16 @@ HibernateDoc.OutdatedContent = (function() {
 					pageHash = jQuery_3_1('div.titlepage h2.title a').attr('id');
 					stableUrl = json.multi.target.replace('${version}', json.stable);
 				}
-			} else if (matchSingle && matchSingle.length == 3) {
+			} else if (matchSingle && matchSingle.length > 2) {
 				var currentVersion = matchSingle[1];
 				if (currentVersion == json.stable || _isNewerThan(currentVersion, json.stable) || currentVersion == 'stable' || currentVersion == 'current') {
 					return;
 				}
-
-				stableUrl = json.single.target.replace('${version}', json.stable).replace('${page}', '');
+				if (json.single.useCurrentUrl) {
+					stableUrl = currentUrl.replace(currentVersion, json.stable);
+				} else {
+					stableUrl = json.single.target.replace('${version}', json.stable).replace('${page}', '');
+				}
 			} else {
 				return;
 			}

--- a/_outdated-content/search.json
+++ b/_outdated-content/search.json
@@ -6,8 +6,9 @@
     "#redirect to single page for now": "/hibernate/stable/search/reference/en-US/html/${page}"
   },
   "single": {
-    "pattern": "^/hibernate/search/([^/]+)/reference/en(?:-US)?/html_single/(index.html)?$",
-    "target": "https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/"
+    "pattern": "^/hibernate/search/([^/]+)/(reference|getting-started/(orm|standalone))/en(?:-US)?/html_single/(index.html)?$",
+    "target": "https://docs.jboss.org/hibernate/stable/search/reference/en-US/html_single/",
+    "useCurrentUrl": true
   },
   "stable": "6.1",
   "versions": [


### PR DESCRIPTION
Hey @yrodiere 
I tracked down the problem with https://hibernate.atlassian.net/browse/HSEARCH-5123 (the part about not showing the message box on older getting started guides) to this script+json. 
I'm not sure, though, how this repo is synced since search stable here is 6.1 😨 